### PR TITLE
chore: rename internal name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ __debug_bin*
 
 # I promise i'll fix the name later
 MastodonTwitterAPI*
+TwitterAPIBridge*

--- a/bluesky/blueskyapi.go
+++ b/bluesky/blueskyapi.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Preloading/MastodonTwitterAPI/bridge"
-	"github.com/Preloading/MastodonTwitterAPI/config"
+	"github.com/Preloading/TwitterAPIBridge/bridge"
+	"github.com/Preloading/TwitterAPIBridge/config"
 )
 
 type AuthResponse struct {

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -7,7 +7,7 @@ import (
 	"hash/fnv"
 	"time"
 
-	"github.com/Preloading/MastodonTwitterAPI/db_controller"
+	"github.com/Preloading/TwitterAPIBridge/db_controller"
 )
 
 type RelatedResultsQuery struct {

--- a/db_controller/db_controller.go
+++ b/db_controller/db_controller.go
@@ -8,8 +8,8 @@ import (
 
 	"strconv"
 
-	"github.com/Preloading/MastodonTwitterAPI/config"
-	authcrypt "github.com/Preloading/MastodonTwitterAPI/cryption"
+	"github.com/Preloading/TwitterAPIBridge/config"
+	authcrypt "github.com/Preloading/TwitterAPIBridge/cryption"
 	"github.com/google/uuid"
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Preloading/MastodonTwitterAPI
+module github.com/Preloading/TwitterAPIBridge
 
 go 1.23.2
 

--- a/main.go
+++ b/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"fmt"
 
-	"github.com/Preloading/MastodonTwitterAPI/config"
-	"github.com/Preloading/MastodonTwitterAPI/db_controller"
-	"github.com/Preloading/MastodonTwitterAPI/twitterv1"
+	"github.com/Preloading/TwitterAPIBridge/config"
+	"github.com/Preloading/TwitterAPIBridge/db_controller"
+	"github.com/Preloading/TwitterAPIBridge/twitterv1"
 )
 
 var (

--- a/twitterv1/account.go
+++ b/twitterv1/account.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"sync"
 
-	blueskyapi "github.com/Preloading/MastodonTwitterAPI/bluesky"
-	"github.com/Preloading/MastodonTwitterAPI/bridge"
+	blueskyapi "github.com/Preloading/TwitterAPIBridge/bluesky"
+	"github.com/Preloading/TwitterAPIBridge/bridge"
 	"github.com/gofiber/fiber/v2"
 )
 

--- a/twitterv1/auth.go
+++ b/twitterv1/auth.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"time"
 
-	blueskyapi "github.com/Preloading/MastodonTwitterAPI/bluesky"
-	"github.com/Preloading/MastodonTwitterAPI/bridge"
-	"github.com/Preloading/MastodonTwitterAPI/cryption"
-	"github.com/Preloading/MastodonTwitterAPI/db_controller"
+	blueskyapi "github.com/Preloading/TwitterAPIBridge/bluesky"
+	"github.com/Preloading/TwitterAPIBridge/bridge"
+	"github.com/Preloading/TwitterAPIBridge/cryption"
+	"github.com/Preloading/TwitterAPIBridge/db_controller"
 	"github.com/gofiber/fiber/v2"
 )
 

--- a/twitterv1/cdnproxy.go
+++ b/twitterv1/cdnproxy.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	blueskyapi "github.com/Preloading/MastodonTwitterAPI/bluesky"
+	blueskyapi "github.com/Preloading/TwitterAPIBridge/bluesky"
 	"github.com/gofiber/fiber/v2"
 	"github.com/nfnt/resize"
 )

--- a/twitterv1/connect.go
+++ b/twitterv1/connect.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"time"
 
-	blueskyapi "github.com/Preloading/MastodonTwitterAPI/bluesky"
-	"github.com/Preloading/MastodonTwitterAPI/bridge"
+	blueskyapi "github.com/Preloading/TwitterAPIBridge/bluesky"
+	"github.com/Preloading/TwitterAPIBridge/bridge"
 	"github.com/gofiber/fiber/v2"
 )
 

--- a/twitterv1/discover.go
+++ b/twitterv1/discover.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	blueskyapi "github.com/Preloading/MastodonTwitterAPI/bluesky"
-	"github.com/Preloading/MastodonTwitterAPI/bridge"
+	blueskyapi "github.com/Preloading/TwitterAPIBridge/bluesky"
+	"github.com/Preloading/TwitterAPIBridge/bridge"
 	"github.com/gofiber/fiber/v2"
 )
 

--- a/twitterv1/interaction.go
+++ b/twitterv1/interaction.go
@@ -7,9 +7,9 @@ import (
 	"strconv"
 	"time"
 
-	blueskyapi "github.com/Preloading/MastodonTwitterAPI/bluesky"
-	"github.com/Preloading/MastodonTwitterAPI/bridge"
-	"github.com/Preloading/MastodonTwitterAPI/db_controller"
+	blueskyapi "github.com/Preloading/TwitterAPIBridge/bluesky"
+	"github.com/Preloading/TwitterAPIBridge/bridge"
+	"github.com/Preloading/TwitterAPIBridge/db_controller"
 	"github.com/gofiber/fiber/v2"
 )
 

--- a/twitterv1/post_viewing.go
+++ b/twitterv1/post_viewing.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 	"time"
 
-	blueskyapi "github.com/Preloading/MastodonTwitterAPI/bluesky"
-	"github.com/Preloading/MastodonTwitterAPI/bridge"
-	"github.com/Preloading/MastodonTwitterAPI/db_controller"
+	blueskyapi "github.com/Preloading/TwitterAPIBridge/bluesky"
+	"github.com/Preloading/TwitterAPIBridge/bridge"
+	"github.com/Preloading/TwitterAPIBridge/db_controller"
 	"github.com/gofiber/fiber/v2"
 )
 

--- a/twitterv1/twitterv1.go
+++ b/twitterv1/twitterv1.go
@@ -6,8 +6,8 @@ import (
 	"encoding/xml"
 	"fmt"
 
-	blueskyapi "github.com/Preloading/MastodonTwitterAPI/bluesky"
-	"github.com/Preloading/MastodonTwitterAPI/config"
+	blueskyapi "github.com/Preloading/TwitterAPIBridge/bluesky"
+	"github.com/Preloading/TwitterAPIBridge/config"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/logger"
 )

--- a/twitterv1/user.go
+++ b/twitterv1/user.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"strings"
 
-	blueskyapi "github.com/Preloading/MastodonTwitterAPI/bluesky"
-	"github.com/Preloading/MastodonTwitterAPI/bridge"
+	blueskyapi "github.com/Preloading/TwitterAPIBridge/bluesky"
+	"github.com/Preloading/TwitterAPIBridge/bridge"
 	"github.com/gofiber/fiber/v2"
 )
 


### PR DESCRIPTION
BREAKING CHANGE: The internal name has been renamed, which means builds are stored in different locations.