### PR TITLE
Add HTC Peep for Windows Mobile support

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -54,3 +54,7 @@ some ios 5 version or smth: Requires PIN auth, which is unimplemented.
 ## Playstation Vita
 ### Livetweet
 ⚠️: Can log in, has major (fixable) issues. Also image upload boundary sillyness. Requires the following Vita plugin: https://silica.codes/Li/LiveSky
+
+## Windows Mobile
+### HTC Peep
+⚠️: 2.5.20172330, Can log in, and most common features work. Investigation on what doesn't work is underway. How to patch (coming soon): https://github.com/htc-remanila/resources

--- a/static/authorize.html
+++ b/static/authorize.html
@@ -46,9 +46,10 @@
 
           <form action="/oauth/authorize" id="oauth_form" method="post" target="_self">
             <div>
-              <input name="username" type="text" placeholder="Username"><br><br>
-              <input name="password" type="password" placeholder="Password">
+              <input class="text" id="username_or_email" name="session[username_or_email]" type="text" placeholder="Username"><br><br>
+              <input class="password" id="session[password]" name="session[password]" type="password" placeholder="Password">
             </div>
+            <input name="authenticity_token" type="hidden" value="authtok">
             <input id="oauth_token" name="oauth_token" type="hidden" value="{{.OauthToken}}">
             <input id="auth_type" name="auth_type" type="hidden" value="apppassword">
             <fieldset class="buttons">

--- a/twitterv1/auth.go
+++ b/twitterv1/auth.go
@@ -182,6 +182,7 @@ func GetAuthFromReq(c *fiber.Ctx) (*string, *string, *string, *string, error) {
 
 		// separate the username and password
 		username = strings.Split(basicAuthUsernamePassword, ":")[0]
+    username = strings.TrimPrefix(username, "@")
 		authPassword = strings.Split(basicAuthUsernamePassword, ":")[1]
 
 		accessJwt, refreshJwt, access_expiry, refresh_expiry, userPDS, did, basicHashSalt, basicAuthSalt, basicUUID, err = db_controller.GetTokenViaBasic(username, authPassword)

--- a/twitterv1/auth.go
+++ b/twitterv1/auth.go
@@ -182,7 +182,7 @@ func GetAuthFromReq(c *fiber.Ctx) (*string, *string, *string, *string, error) {
 
 		// separate the username and password
 		username = strings.Split(basicAuthUsernamePassword, ":")[0]
-    username = strings.TrimPrefix(username, "@")
+		username = strings.TrimPrefix(username, "@")
 		authPassword = strings.Split(basicAuthUsernamePassword, ":")[1]
 
 		accessJwt, refreshJwt, access_expiry, refresh_expiry, userPDS, did, basicHashSalt, basicAuthSalt, basicUUID, err = db_controller.GetTokenViaBasic(username, authPassword)

--- a/twitterv1/oauth.go
+++ b/twitterv1/oauth.go
@@ -254,9 +254,10 @@ func AttemptToAuthenticateWithOauth(c *fiber.Ctx) error {
 		return c.Status(400).SendString("invalid/expired oauth_token")
 	}
 
-	if c.FormValue("auth_type") == "apppassword" {
-		username := c.FormValue("username")
-		password := c.FormValue("password")
+	// if c.FormValue("auth_type") == "apppassword" {
+  if true { // fix this when more auth types are added (if they exist)
+		username := c.FormValue("session[username_or_email]")
+		password := c.FormValue("session[password]")
 
 		res, pds, err := blueskyapi.Authenticate(username, password)
 		if err != nil {
@@ -279,7 +280,8 @@ func AttemptToAuthenticateWithOauth(c *fiber.Ctx) error {
 			}
 
 			tempTokens.Store(oauth_token, tokenData)
-			return c.SendString(fmt.Sprintf("Your pin is %s. Use it in the app you are trying to log into.", tokenData.Verifier))
+			c.Set("Content-Type", "text/html")
+			return c.SendString(fmt.Sprintf(`<html><body><div id="oauth_pin">%s</div></body></html>`, tokenData.Verifier))
 		} else {
 			// random base64 data
 			tokenData.Verifier = rand.Text()
@@ -336,8 +338,10 @@ func OAuthAccessToken(c *fiber.Ctx) error {
 	}
 
 	tempTokens.Delete(oauthParams.Verifier)
+  
+  
 
-	if tokenData.Verifier != oauthParams.Verifier {
+	if tokenData.Verifier != oauthParams.Verifier && tokenData.Verifier != c.Query("oauth_verifier") {
 		return c.Status(400).SendString("incorrect verifier, try again")
 	}
 

--- a/twitterv1/oauth.go
+++ b/twitterv1/oauth.go
@@ -281,7 +281,7 @@ func AttemptToAuthenticateWithOauth(c *fiber.Ctx) error {
 
 			tempTokens.Store(oauth_token, tokenData)
 			c.Set("Content-Type", "text/html")
-			return c.SendString(fmt.Sprintf(`<html><body><div id="oauth_pin">%s</div></body></html>`, tokenData.Verifier))
+			return c.SendString(fmt.Sprintf(`<html><body><p>Your OAuth PIN is: <div id="oauth_pin">%s</div></p><p>Use it in the app you are trying to log into.</p></body></html>`, tokenData.Verifier))
 		} else {
 			// random base64 data
 			tokenData.Verifier = rand.Text()

--- a/twitterv1/oauth.go
+++ b/twitterv1/oauth.go
@@ -255,7 +255,7 @@ func AttemptToAuthenticateWithOauth(c *fiber.Ctx) error {
 	}
 
 	// if c.FormValue("auth_type") == "apppassword" {
-  if true { // fix this when more auth types are added (if they exist)
+	if true { // fix this when more auth types are added (if they exist)
 		username := c.FormValue("session[username_or_email]")
 		password := c.FormValue("session[password]")
 
@@ -338,8 +338,6 @@ func OAuthAccessToken(c *fiber.Ctx) error {
 	}
 
 	tempTokens.Delete(oauthParams.Verifier)
-  
-  
 
 	if tokenData.Verifier != oauthParams.Verifier && tokenData.Verifier != c.Query("oauth_verifier") {
 		return c.Status(400).SendString("incorrect verifier, try again")

--- a/twitterv1/twitterv1.go
+++ b/twitterv1/twitterv1.go
@@ -162,6 +162,11 @@ func InitServer(config *config.Config) {
 	app.Get("/i/discovery.:filetype", discovery)
 
 	app.Get("/1.1/discovery/universal.:filetype", discovery)
+  
+	// search.twitter.com -> /search (for easy patching)
+	app.Get("/search/trends/:woeid.:filetype", trends_woeid)
+	app.Get("/search/trends/current.:filetype", trends_woeid)
+  // todo: point search, daily and weekly to the relevant functions (when they appear)
 
 	// Lists
 	AddV1Path(app.Get, "/lists.:filetype", GetUsersLists)

--- a/twitterv1/twitterv1.go
+++ b/twitterv1/twitterv1.go
@@ -162,11 +162,11 @@ func InitServer(config *config.Config) {
 	app.Get("/i/discovery.:filetype", discovery)
 
 	app.Get("/1.1/discovery/universal.:filetype", discovery)
-  
+
 	// search.twitter.com -> /search (for easy patching)
 	app.Get("/search/trends/:woeid.:filetype", trends_woeid)
 	app.Get("/search/trends/current.:filetype", trends_woeid)
-  // todo: point search, daily and weekly to the relevant functions (when they appear)
+	// todo: point search, daily and weekly to the relevant functions (when they appear)
 
 	// Lists
 	AddV1Path(app.Get, "/lists.:filetype", GetUsersLists)


### PR DESCRIPTION
This PR lets HTC Peep for Windows Mobile log in through the bridge

### Changes
- Added `authenticity_token` to `authorize.html` - parser treats its absence as fatal even though it doesn't validate the value
- Renamed credential form fields to `session[username_or_email]` and `session[password]` to match what clients expect
- Practically removed `auth_type` gate from `AttemptToAuthenticateWithOauth` temporarily - `apppassword` is the default, when adding additional types change this
- Strip leading `@` from username in Basic auth paths - Peep prefixes handles with `@`
- Wrap OOB PIN response in `<div id="oauth_pin">` so the client's string scraper can extract it
- Fall back to `oauth_verifier` query param if not present in `Authorization` header - Peep sends it as a query param on the access token GET
- Added `/search` route prefix so that `search.twitter.com` can be patched to point to it